### PR TITLE
Add "ATM" option to the TPoS to use LUD-19 withdraw request to top up a wallet (e.g. bolt card)

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -10,8 +10,8 @@ async def create_tpos(wallet_id: str, data: CreateTposData) -> TPoS:
     tpos_id = urlsafe_short_hash()
     await db.execute(
         """
-        INSERT INTO tpos.tposs (id, wallet, name, currency, tip_options, tip_wallet)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO tpos.tposs (id, wallet, name, currency, tip_options, tip_wallet, atm)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
         (
             tpos_id,
@@ -20,6 +20,7 @@ async def create_tpos(wallet_id: str, data: CreateTposData) -> TPoS:
             data.currency,
             data.tip_options,
             data.tip_wallet,
+            data.atm
         ),
     )
 

--- a/migrations.py
+++ b/migrations.py
@@ -34,3 +34,13 @@ async def m003_addtip_options(db):
         ALTER TABLE tpos.tposs ADD tip_options TEXT NULL;
     """
     )
+
+async def m004_addatm_options(db):
+    """
+    Add tips to tposs table
+    """
+    await db.execute(
+        """
+        ALTER TABLE tpos.tposs ADD atm BOOLEAN NULL;
+    """
+    )

--- a/models.py
+++ b/models.py
@@ -10,6 +10,7 @@ class CreateTposData(BaseModel):
     currency: str
     tip_options: str = Query(None)
     tip_wallet: str = Query(None)
+    atm: bool = Query(None)
 
 
 class TPoS(BaseModel):
@@ -19,6 +20,7 @@ class TPoS(BaseModel):
     currency: str
     tip_options: Optional[str]
     tip_wallet: Optional[str]
+    atm: Optional[bool]
 
     @classmethod
     def from_row(cls, row: Row) -> "TPoS":

--- a/templates/tpos/index.html
+++ b/templates/tpos/index.html
@@ -92,6 +92,8 @@
             (round amount to a value)
           </template>
         </q-select>
+        <q-checkbox filled dense emit-value v-model="formDialog.data.atm" :options="g.user.walletOptions"
+          label="ATM"></q-checkbox>
         <div class="row q-mt-lg">
           <q-btn unelevated color="primary" :disable="formDialog.data.currency == null || formDialog.data.name == null"
             type="submit">Create TPoS</q-btn>
@@ -314,7 +316,13 @@
               align: 'left',
               label: 'Tip Options %',
               field: 'tip_options'
-            }
+            },
+            {
+              name: 'atm',
+              align: 'left',
+              label: 'Allow ATM',
+              field: 'atm'
+            },
           ],
           pagination: {
             rowsPerPage: 10
@@ -354,7 +362,8 @@
               this.formDialog.data.tip_options.map(str => parseInt(str))
             )
             : JSON.stringify([]),
-          tip_wallet: this.formDialog.data.tip_wallet || ''
+          tip_wallet: this.formDialog.data.tip_wallet || '',
+          atm: this.formDialog.data.atm || 0
         }
         const wallet = _.findWhere(this.g.user.wallets, {
           id: this.formDialog.data.wallet

--- a/templates/tpos/index.html
+++ b/templates/tpos/index.html
@@ -330,7 +330,9 @@
         },
         formDialog: {
           show: false,
-          data: {}
+          data: {
+            atm: false
+          }
         }
       }
     },

--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -516,6 +516,14 @@
       makeAtmWithdraw: function (payLink, readerAbortController) {
         const self = this
 
+        if (!payLink){
+          this.$q.notify({
+                type: 'negative',
+                message: "Card doesn't support the ATM topup feature (LUD-19)"
+              })
+           return
+        }
+
         return axios
           .post(
             '/tpos/api/v1/tposs/' +
@@ -539,6 +547,10 @@
             else {
               this.stack = []
               this.tipAmount = 0.0
+              this.$q.notify({
+                type: 'positive',
+                message: "Topup successful!"
+              })
             }
 
             readerAbortController.abort()

--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -56,7 +56,7 @@
     <q-page-sticky position="top-right" :offset="[18, 162]">
       <q-btn
         :disabled="amount == 0"
-        @click="readAtmNfcTag"
+        @click="readNfcTag('atm')"
         fab
         color="primary"
       />ATM</q-btn>
@@ -374,7 +374,7 @@
             LNbits.utils.notifyApiError(error)
           })
       },
-      readNfcTag: function () {
+      readNfcTag: function (atm=false) {
         try {
           const self = this
 
@@ -423,79 +423,15 @@
 
               //User feedback, show loader icon
               self.nfcTagReading = false
-              self.payInvoice(lnurl, readerAbortController)
 
-              this.$q.notify({
-                type: 'positive',
-                message: 'NFC tag read successfully.'
-              })
-            }
-          })
-        } catch (error) {
-          this.nfcTagReading = false
-          this.$q.notify({
-            type: 'negative',
-            message: error
-              ? error.toString()
-              : 'An unexpected error has occurred.'
-          })
-        }
-      },
-      readAtmNfcTag: function () {
-        try {
-          const self = this
-
-          if (typeof NDEFReader == 'undefined') {
-            throw {
-              toString: function () {
-                return 'NFC not supported on this device or browser.'
+              if (atm){
+                axios.get(lnurl.replace('lnurlw://', 'https://')).then(function (response) {
+                  console.log(response.data.payLink)
+                  self.makeAtmWithdraw(response.data.payLink, readerAbortController)
+                })
+              } else {
+                self.payInvoice(lnurl, readerAbortController)
               }
-            }
-          }
-
-          const ndef = new NDEFReader()
-
-          const readerAbortController = new AbortController()
-          readerAbortController.signal.onabort = event => {
-            console.log('All NFC Read operations have been aborted.')
-          }
-
-          this.nfcTagReading = true
-          this.$q.notify({
-            message: 'Tap your NFC tag to pay this invoice with LNURLw.'
-          })
-
-          return ndef.scan({signal: readerAbortController.signal}).then(() => {
-            ndef.onreadingerror = () => {
-              self.nfcTagReading = false
-
-              this.$q.notify({
-                type: 'negative',
-                message: 'There was an error reading this NFC tag.'
-              })
-
-              readerAbortController.abort()
-            }
-
-            ndef.onreading = ({message}) => {
-              //Decode NDEF data from tag
-              const textDecoder = new TextDecoder('utf-8')
-
-              const record = message.records.find(el => {
-                const payload = textDecoder.decode(el.data)
-                return payload.toUpperCase().indexOf('LNURL') !== -1
-              })
-
-              const lnurl = textDecoder.decode(record.data)
-
-              //User feedback, show loader icon
-              self.nfcTagReading = false
-              //self.payInvoice(lnurl, readerAbortController)
-
-              axios.get(lnurl.replace('lnurlw://', 'https://')).then(function (response) {
-                console.log(response.data.payLink)
-                self.makeAtmWithdraw(response.data.payLink, readerAbortController)
-              })
 
               this.$q.notify({
                 type: 'positive',

--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -437,6 +437,7 @@
                 type: 'positive',
                 message: 'NFC tag read successfully.'
               })
+              readerAbortController.abort()
             }
           })
         } catch (error) {

--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -53,6 +53,14 @@
     <q-page-sticky position="top-right" :offset="[18, 90]">
       <q-btn @click="toggleFullscreen" fab :icon="fullScreenIcon" color="primary" />
     </q-page-sticky>
+    <q-page-sticky position="top-right" :offset="[18, 162]">
+      <q-btn
+        :disabled="amount == 0"
+        @click="readAtmNfcTag"
+        fab
+        color="primary"
+      />ATM</q-btn>
+    </q-page-sticky>
     <q-dialog v-model="invoiceDialog.show" position="top" @hide="closeInvoiceDialog">
       <q-card v-if="invoiceDialog.data" class="q-pa-lg q-pt-xl lnbits__dialog-card">
         <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
@@ -187,6 +195,7 @@
         tposId: '{{ tpos.id }}',
         currency: '{{ tpos.currency }}',
         tip_options: null,
+        atm: null,
         exchangeRate: null,
         stack: [],
         tipAmount: 0.0,
@@ -431,6 +440,109 @@
               : 'An unexpected error has occurred.'
           })
         }
+      },
+      readAtmNfcTag: function () {
+        try {
+          const self = this
+
+          if (typeof NDEFReader == 'undefined') {
+            throw {
+              toString: function () {
+                return 'NFC not supported on this device or browser.'
+              }
+            }
+          }
+
+          const ndef = new NDEFReader()
+
+          const readerAbortController = new AbortController()
+          readerAbortController.signal.onabort = event => {
+            console.log('All NFC Read operations have been aborted.')
+          }
+
+          this.nfcTagReading = true
+          this.$q.notify({
+            message: 'Tap your NFC tag to pay this invoice with LNURLw.'
+          })
+
+          return ndef.scan({signal: readerAbortController.signal}).then(() => {
+            ndef.onreadingerror = () => {
+              self.nfcTagReading = false
+
+              this.$q.notify({
+                type: 'negative',
+                message: 'There was an error reading this NFC tag.'
+              })
+
+              readerAbortController.abort()
+            }
+
+            ndef.onreading = ({message}) => {
+              //Decode NDEF data from tag
+              const textDecoder = new TextDecoder('utf-8')
+
+              const record = message.records.find(el => {
+                const payload = textDecoder.decode(el.data)
+                return payload.toUpperCase().indexOf('LNURL') !== -1
+              })
+
+              const lnurl = textDecoder.decode(record.data)
+
+              //User feedback, show loader icon
+              self.nfcTagReading = false
+              //self.payInvoice(lnurl, readerAbortController)
+
+              axios.get(lnurl.replace('lnurlw://', 'https://')).then(function (response) {
+                console.log(response.data.payLink)
+                self.makeAtmWithdraw(response.data.payLink, readerAbortController)
+              })
+
+              this.$q.notify({
+                type: 'positive',
+                message: 'NFC tag read successfully.'
+              })
+            }
+          })
+        } catch (error) {
+          this.nfcTagReading = false
+          this.$q.notify({
+            type: 'negative',
+            message: error
+              ? error.toString()
+              : 'An unexpected error has occurred.'
+          })
+        }
+      },
+      makeAtmWithdraw: function (payLink, readerAbortController) {
+        const self = this
+
+        return axios
+          .post(
+            '/tpos/api/v1/tposs/' +
+              self.tposId +
+              '/atm/', null,
+            {
+              params: {
+                amount: this.sat,
+                memo: this.amountFormatted,
+                payLink: payLink
+              }
+            }
+          )
+          .then(response => {
+            if (!response.data.success) {
+              this.$q.notify({
+                type: 'negative',
+                message: response.data.detail
+              })
+            }
+            else {
+              this.stack = []
+              this.tipAmount = 0.0
+            }
+
+            readerAbortController.abort()
+          })
       },
       payInvoice: function (lnurl, readerAbortController) {
         const self = this

--- a/views_api.py
+++ b/views_api.py
@@ -40,7 +40,6 @@ async def api_tpos_create(
     data: CreateTposData, wallet: WalletTypeInfo = Depends(get_key_type)
 ):
     tpos = await create_tpos(wallet_id=wallet.wallet.id, data=data)
-    print(data)
     return tpos.dict()
 
 

--- a/views_api.py
+++ b/views_api.py
@@ -123,6 +123,8 @@ async def api_tpos_make_atm(
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="TPoS does not exist."
         )
+    if (tpos.atm == 0 or tpos.atm == None):
+        return {"success": False, "detail": "ATM mode not allowed"} 
 
     payLink = payLink.replace("lnurlp://", "https://") # pointless lnurlp:// -> https://
 

--- a/views_api.py
+++ b/views_api.py
@@ -155,17 +155,15 @@ async def api_tpos_make_atm(
                 return {"success": False, "detail": "Error loading callback"}
 
             try:
-
                 payment_hash = await pay_invoice(
                     wallet_id=tpos.wallet,
                     payment_request=cb_resp["pr"],
                     description="ATM Withdrawal",
                     extra={"tag": "tpos_atm", "tpos": tpos.id},
                 )
-
                 return {"success": True, "detail": "Payment successful", "payment_hash": payment_hash}
             except Exception as exc:
-                return {"success": False, "reason": f"Payment failed - {exc}"}
+                return {"success": False, "reason": exc, "detail": f"Payment failed - {exc}"}
 
         except Exception as e:
             raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e))


### PR DESCRIPTION
This PR adds a functionality to withdraw from a wallet by tapping e.g. bolt card that is paired to a backend with LUD-19 support. It works like ATM. 

The ATM must be allowed by the user. Once this is set, anyone that has access to the TPoS can withdraw sats from the wallet up to the wallet balance.

This has to be considered if the TPoS link is handed to any person so he may withdraw all the funds from wallet. Also any "ATM" TPoS link should not be anywhere on web.

All previously configured TPoS are not allowed to withdraw, the user has to explicitly allow the ATM functionality. 

Thanks @iWarp for the initial PoC
https://github.com/iWarpBTC/tpos/commit/5092c7fd68c03c502a42998a33ace9020d5a3e97

