### PR TITLE
remove NFC button, scan the NFC if available right away

### DIFF
--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -41,7 +41,7 @@
               color="primary">0</q-btn>
             <q-btn unelevated @click="stack = []" size="xl" :outline="!($q.dark.isActive)" rounded color="primary"
               class="btn-cancel">C</q-btn>
-            <q-btn unelevated :disabled="amount == 0" @click="submitForm()" size="xl" :outline="!($q.dark.isActive)"
+            <q-btn unelevated :disabled="amount == 0" @click="submitForm(); readNfcTag()" size="xl" :outline="!($q.dark.isActive)"
               rounded color="primary" class="btn-confirm">OK</q-btn>
           </div>
         </div>
@@ -69,7 +69,7 @@
             <span v-show="tip_options" style="font-size: 0.75rem">( + {{ tipAmountFormatted }} tip)</span>
             {% endraw %}
           </h5>
-          <q-btn outline color="grey" icon="nfc" @click="readNfcTag()" :disable="nfcTagReading"></q-btn>
+          <!--<q-btn outline color="grey" icon="nfc" @click="readNfcTag()" :disable="nfcTagReading"></q-btn>-->
         </div>
         <div class="row q-mt-lg">
           <q-btn outline color="grey" @click="copyText(invoiceDialog.data.payment_request)">Copy invoice</q-btn>
@@ -372,7 +372,9 @@
           if (typeof NDEFReader == 'undefined') {
             throw {
               toString: function () {
-                return 'NFC not supported on this device or browser.'
+                this.$q.notify({
+                  message: 'scanning nfc'
+                })
               }
             }
           }

--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -357,6 +357,9 @@
                     dialog.show = false
 
                     self.complete.show = true
+                    setTimeout(function () {
+                      self.complete.show = false
+                    }, 5000)
                   }
                 })
             }, 3000)


### PR DESCRIPTION
When working with POS, people forgets to "tap" the NFC button when paying. It's better to try scanning the nfc right after the invoice is generated.

On desktop, where NFC is not by default it is not a problem, actually this is a better UX because it doesn't confuses the user with error "NFC not supported on this device".

On device with NFC it works automatically now.