### PR TITLE
reintroduce POS button colors (red, yellow, green)

### DIFF
--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -115,7 +115,7 @@
                 size="xl"
                 :outline="!($q.dark.isActive)"
                 rounded
-                color="secondary"
+                color="negative"
                 >C</q-btn
               >
               <q-btn
@@ -133,7 +133,7 @@
                 size="xl"
                 :outline="!($q.dark.isActive)"
                 rounded
-                color="secondary"
+                color="warning"
                 class="btn-cancel"
                 >⬅</q-btn
               >
@@ -153,7 +153,7 @@
                 size="xl"
                 :outline="!($q.dark.isActive)"
                 rounded
-                color="secondary"
+                color="positive"
                 class="btn-confirm"
                 >Ok</q-btn
               >


### PR DESCRIPTION
merchants using POS are used to these colors:

<img src="https://img.merkandi.com/imgcache/resized/images/offer/2023/07/13/ingenico-ipp350-1689239757-1689239762.jpg" width="250"> <img src="https://www.six-payment-services.com/dam/images/terminals/ingenico-move-3500.png" width="250"> <img src="https://www.investsmall.co/wp-content/uploads/2020/12/pos-machines.jpg" width="250">
