### PR TITLE
Change "Exit ATM MODE" from rectangle to button

### DIFF
--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -39,6 +39,15 @@
           </div>
         </div>
       </div>
+      <div class="col-12 col-sm-8 col-md-6 col-lg-4 text-center">
+        <q-btn
+          @click="() => {atmMode = false; getRates()}"
+          v-if="atmMode == true"
+          rounded
+          color="negative"
+          >EXIT ATM</div
+        >
+      </div>
     </q-page-sticky>
     <template v-if="showPoS">
       <q-page-sticky expand position="bottom">
@@ -197,7 +206,7 @@
       <q-page-sticky position="top-right" :offset="[18, 162]">
         <q-btn
           @click="atm"
-          v-if="withdrawamtposs > 0"
+          v-if="withdrawamtposs > 0 && !atmMode"
           fab
           icon="atm"
           color="primary"
@@ -412,13 +421,6 @@
         ></q-page-sticky
       >
     </template>
-    <q-btn
-      v-show="atmMode"
-      color="negative"
-      @click="() => {atmMode = false; getRates()}"
-      class="absolute-top-left"
-      >EXIT ATM MODE</q-btn
-    >
     <q-dialog
       v-model="invoiceDialog.show"
       position="top"


### PR DESCRIPTION
Proposal for more streamlined visuals for ATM mode

**Current legend tpos-ATM mode**
![image](https://github.com/lnbits/tpos/assets/7249767/4b70a880-f40e-4e2d-8c58-ef3899de6f91)

**PR provided tpos ATM mode**
![image](https://github.com/lnbits/tpos/assets/7249767/3ea89a94-c790-4f78-8a41-9199ae8f7ee0)
