### PR TITLE
hotfix atm premium

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -21,8 +21,8 @@ async def create_tpos(wallet_id: str, data: CreateTposData) -> TPoS:
     tpos_id = urlsafe_short_hash()
     await db.execute(
         """
-        INSERT INTO tpos.pos (id, wallet, name, currency, tip_options, tip_wallet, withdrawlimit, withdrawpin, withdrawamt, withdrawtime, withdrawbtwn, withdrawtimeopt, withdrawpindisabled)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO tpos.pos (id, wallet, name, currency, tip_options, tip_wallet, withdrawlimit, withdrawpin, withdrawamt, withdrawtime, withdrawbtwn, withdrawtimeopt, withdrawpindisabled, withdrawpremium)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             tpos_id,
@@ -38,6 +38,7 @@ async def create_tpos(wallet_id: str, data: CreateTposData) -> TPoS:
             data.withdrawbtwn,
             data.withdrawtimeopt,
             data.withdrawpindisabled,
+            data.withdrawpremium,
         ),
     )
     tpos = await get_tpos(tpos_id)

--- a/templates/tpos/index.html
+++ b/templates/tpos/index.html
@@ -432,10 +432,9 @@
             dense
             v-model.number="formDialog.data.withdrawpremium"
             type="number"
-            label="Withdraw premium (0.00 to 1.00 %)"
+            label="Withdraw premium %"
             step="0.01"
             min="0"
-            max="1"
           ></q-input>
         </template>
 

--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -1387,7 +1387,6 @@
         // cancel the default action to avoid it being handled twice
         event.preventDefault()
       })
-
       setInterval(function () {
         getRates()
       }, 120000)


### PR DESCRIPTION
- ATM premium wasn't stored in the DB
- Value asked in the input is now in percentage (ex: 1, 3.5, etc...)

**Test Steps**:
- create or edit a tpos that allows ATM withdraw and set a premium percentage, for testing purposes make that a high value like 20%
- make the withdraw, check the exchange rate, it should be ~20% less than actual exchange rate (you should get less sats than doing it with the actual rate) 

**Actual Result**:
- atm premium setting wasn't added to DB
- atm premium was always 0%, so the real exchange rate was used

**Expected Result**:
- the premium value should show on the tpos table
- the withdraw should account the premium and adjust the amount of sats to withdraw
