### PR TITLE
Check for funds on ATM

### DIFF
--- a/static/js/tpos.js
+++ b/static/js/tpos.js
@@ -286,6 +286,13 @@ const tposJS = async () => {
       atmGetWithdraw: function () {
         self = this
         var dialog = this.invoiceDialog
+        if (this.sat > this.withdrawamtposs) {
+          this.$q.notify({
+            type: 'negative',
+            message: 'Amount exceeds the maximum withdrawal limit.'
+          })
+          return
+        }
         LNbits.api
           .request(
             'GET',

--- a/static/js/tpos.js
+++ b/static/js/tpos.js
@@ -299,6 +299,13 @@ const tposJS = async () => {
             `/tpos/api/v1/atm/withdraw/` + this.atmToken + `/` + this.sat
           )
           .then(function (res) {
+            if (res.data.status == 'ERROR') {
+              self.$q.notify({
+                type: 'negative',
+                message: res.data.reason
+              })
+              return
+            }
             lnurl = res.data.lnurl
             dialog.data = {payment_request: lnurl}
             dialog.show = true
@@ -335,7 +342,7 @@ const tposJS = async () => {
                 this.connectionWithdraw.close()
               }
             }
-            this.getRates()
+            self.getRates()
           })
           .catch(function (error) {
             LNbits.utils.notifyApiError(error)

--- a/views_api.py
+++ b/views_api.py
@@ -7,6 +7,7 @@ from lnbits.core.crud import (
     get_latest_payments_by_extension,
     get_standalone_payment,
     get_user,
+    get_wallet,
 )
 from lnbits.core.models import Payment, WalletTypeInfo
 from lnbits.core.services import create_invoice
@@ -333,6 +334,16 @@ async def api_tpos_create_withdraw(
             "status": "ERROR",
             "reason": f"TPoS {lnurlcharge.tpos_id} not found on this server",
         }
+
+    wallet = await get_wallet(tpos.wallet)
+    assert wallet
+    balance = int(wallet.balance_msat / 1000)
+    if balance < int(amount):
+        return {
+            "status": "ERROR",
+            "reason": f"Insufficient balance. Your balance is {balance} sats",
+        }
+
     lnurlcharge = await update_lnurlcharge(
         LNURLCharge(
             id=withdraw_token,


### PR DESCRIPTION
Check and display error if available balance is less than requested on ATM.

- check if amount exceeds withdraw limit
- check if amount exceeds available wallet balance
- fixed `this` error on get_rates 