### PR TITLE
[Fix] Numeric input on mobile

### DIFF
--- a/templates/tpos/dialogs.html
+++ b/templates/tpos/dialogs.html
@@ -207,11 +207,13 @@
         <div class="text-h6">Withdraw PIN</div>
       </q-card-section>
       <q-card-section>
-        <q-form autofocus @submit="atmSubmit" class="q-gutter-md">
+        <q-form @submit="atmSubmit" class="q-gutter-md">
           <q-input
+            autofocus
             filled
             :type="hidePin ? 'password' : 'number'"
             v-model.number="atmPin"
+            inputmode="numeric"
             ><template v-slot:append>
               <q-icon
                 :name="hidePin ? 'visibility_off' : 'visibility'"

--- a/templates/tpos/index.html
+++ b/templates/tpos/index.html
@@ -379,6 +379,7 @@
             use-chips
             hide-dropdown-icon
             input-debounce="0"
+            inputmode="numeric"
             new-value-mode="add-unique"
             label="Tip % Options (hit enter to add values)"
             ><q-tooltip>Hit enter to add values</q-tooltip>


### PR DESCRIPTION
Fixes inconsistent keyboard type on mobile.

ATM pin now has autofocus and numeric keyboard
Tip setting also uses the numeric keyboard on mobile

Closes #75
Closes #130