### PR TITLE
fix: improve tablet/wide UX

### DIFF
--- a/static/components/payment-method-selector.js
+++ b/static/components/payment-method-selector.js
@@ -1,0 +1,116 @@
+window.app.component('tpos-payment-method-selector', {
+  name: 'tpos-payment-method-selector',
+  props: {
+    bitcoinSymbol: {type: String, required: true},
+    currency: {type: String, required: true},
+    currencySymbol: {type: String, required: true},
+    fiatProvider: {type: Boolean, default: false},
+    allowCashSettlement: {type: Boolean, default: false},
+    onchainEnabled: {type: Boolean, default: false},
+    tabsEnabled: {type: Boolean, default: false},
+    isSettlingTab: {type: Boolean, default: false},
+    drawer: {type: Boolean, default: false},
+    disabled: {type: Boolean, default: false}
+  },
+  emits: ['select'],
+  template: `
+    <div class="row q-col-gutter-sm q-pt-xs">
+      <div class="col-6">
+        <q-btn
+          class="full-width q-px-lg q-py-sm"
+          :size="drawer ? 'lg' : 'xl'"
+          color="primary"
+          rounded
+          :disable="disabled"
+          aria-label="Lightning Network"
+          @click="$emit('select', 'btc')"
+        >
+          <div class="row items-center no-wrap q-gutter-x-sm">
+            <span class="text-h4 text-weight-bold" v-text="bitcoinSymbol"></span>
+            <span class="text-subtitle1 text-weight-medium">Lightning</span>
+          </div>
+        </q-btn>
+      </div>
+      <div class="col-6" v-if="onchainEnabled">
+        <q-btn
+          class="full-width q-px-lg q-py-sm"
+          :size="drawer ? 'lg' : 'xl'"
+          color="primary"
+          rounded
+          :disable="disabled"
+          aria-label="Bitcoin Onchain"
+          @click="$emit('select', 'btc_onchain')"
+        >
+          <div class="row items-center no-wrap q-gutter-x-sm">
+            <span class="text-h4 text-weight-bold" v-text="bitcoinSymbol"></span>
+            <span class="text-subtitle1 text-weight-medium">Onchain</span>
+          </div>
+        </q-btn>
+      </div>
+      <div class="col-6" v-if="fiatProvider">
+        <q-btn
+          class="full-width q-px-lg q-py-sm"
+          :size="drawer ? 'lg' : 'xl'"
+          color="secondary"
+          rounded
+          :disable="disabled"
+          :aria-label="currency + ' QR'"
+          @click="$emit('select', 'fiat')"
+        >
+          <div class="row items-center no-wrap q-gutter-x-xs">
+            <span class="text-h5 text-weight-bold" v-text="currencySymbol"></span>
+            <q-icon name="qr_code" size="30px"></q-icon>
+          </div>
+        </q-btn>
+      </div>
+      <div class="col-6" v-if="allowCashSettlement && currency != 'sats'">
+        <q-btn
+          class="full-width q-px-lg q-py-sm"
+          :size="drawer ? 'lg' : 'xl'"
+          color="secondary"
+          rounded
+          :disable="disabled"
+          :aria-label="currency + ' TAP'"
+          @click="$emit('select', 'cash')"
+        >
+          <div class="row items-center no-wrap q-gutter-x-xs">
+            <span class="text-h5 text-weight-bold" v-text="currencySymbol"></span>
+            <q-icon name="toll" size="30px"></q-icon>
+          </div>
+        </q-btn>
+      </div>
+      <div class="col-6" v-if="fiatProvider">
+        <q-btn
+          class="full-width q-px-lg q-py-sm"
+          :size="drawer ? 'lg' : 'xl'"
+          color="secondary"
+          rounded
+          :disable="disabled"
+          :aria-label="'CASH ' + currency"
+          @click="$emit('select', 'fiat_tap')"
+        >
+          <div class="row items-center no-wrap q-gutter-x-xs">
+            <span class="text-h5 text-weight-bold" v-text="currencySymbol"></span>
+            <q-icon name="credit_card" size="30px"></q-icon>
+          </div>
+        </q-btn>
+      </div>
+      <div class="col-6" v-if="tabsEnabled && !isSettlingTab">
+        <q-btn
+          class="full-width q-px-lg q-py-sm"
+          :size="drawer ? 'lg' : 'xl'"
+          color="secondary"
+          rounded
+          :disable="disabled"
+          aria-label="Add to tab"
+          @click="$emit('select', 'tab')"
+        >
+          <div class="row items-center no-wrap q-gutter-x-xs">
+            <q-icon class="text-h4" name="playlist_add_check"></q-icon>
+            <span class="text-subtitle1 text-weight-medium">Tab</span>
+          </div>
+        </q-btn>
+      </div>
+    </div>
+  `
+})

--- a/static/js/tpos.js
+++ b/static/js/tpos.js
@@ -4,6 +4,11 @@ const {
   roundTposCurrencyAmount
 } = window.tposUtils
 
+const TILE_SIZE_DEFAULT = 150
+const TILE_SIZE_MIN = 80
+const TILE_SIZE_MAX = 240
+const TILE_SIZE_STEP = 10
+
 window.app = Vue.createApp({
   el: '#vue',
   mixins: [window.windowMixin],
@@ -92,6 +97,7 @@ window.app = Vue.createApp({
       rounding: false,
       isFullScreen: false,
       isGridView: this.$q.screen.gt.sm,
+      tileSize: TILE_SIZE_DEFAULT,
       moreBtn: false,
       total: 0.0,
       cartTax: 0.0,
@@ -312,8 +318,14 @@ window.app = Vue.createApp({
     drawerWidth() {
       return this.$q.screen.lt.sm ? 360 : 450
     },
-    drawerItemsHeight() {
-      return `overflow-y: auto; height: ${this.$q.screen.gt.sm ? 'calc(100vh - 400px)' : 'calc(100vh - 465px)'}`
+    tileSizeStorageKey() {
+      return `lnbits.tpos.${this.tposId}.tileSize`
+    },
+    tileImageStyle() {
+      return {
+        height: `${Math.max(this.tileSize - 36, 32)}px`,
+        flex: '0 0 auto'
+      }
     },
     formattedCartTax() {
       return this.formatAmount(this.cartTax, this.currency)
@@ -1892,6 +1904,9 @@ window.app = Vue.createApp({
     this.amountFormatted = this.formatAmount(this.amount, this.currency)
     this.totalFormatted = this.formatAmount(this.total, this.currency)
     this.tposId = tpos.id
+    this.tileSize = this.normalizeTileSize(
+      this.$q.localStorage.getItem(this.tileSizeStorageKey)
+    )
     this.atmPremium = tpos.withdraw_premium / 100
     this.withdrawMaximum = withdraw_maximum
     this.pinDisabled = tpos.withdraw_pin_disabled

--- a/static/js/tpos.js
+++ b/static/js/tpos.js
@@ -80,7 +80,8 @@ window.app = Vue.createApp({
       pendingTabSettlement: null,
       cashValidating: false,
       tipDialog: {
-        show: false
+        show: false,
+        paymentMethod: null
       },
       urlDialog: {
         show: false
@@ -917,17 +918,19 @@ window.app = Vue.createApp({
       }, 3000)
     },
     processTipSelection(selectedTipOption) {
+      const selectedPaymentMethod = this.tipDialog.paymentMethod
+      this.tipDialog.paymentMethod = null
       this.tipDialog.show = false
       if (!selectedTipOption) {
         this.tipAmount = 0.0
-        return this.showInvoice()
+        return this.showInvoice(selectedPaymentMethod)
       }
 
       this.tipAmount = roundTposCurrencyAmount(
         (selectedTipOption / 100) * this.activePaymentAmount,
         this.currency
       )
-      this.showInvoice()
+      this.showInvoice(selectedPaymentMethod)
     },
     resetPaymentAttempt() {
       this.paymentAmount = null
@@ -935,7 +938,7 @@ window.app = Vue.createApp({
       this.rounding = false
       this.tipRounding = null
     },
-    submitForm() {
+    submitForm(selectedPaymentMethod = null) {
       const paymentAmount =
         this.total > 0.0
           ? roundTposCurrencyAmount(this.total + this.amount, this.currency)
@@ -945,6 +948,7 @@ window.app = Vue.createApp({
       this.sat = Math.ceil(paymentAmount * this.exchangeRate)
 
       if (!this.exchangeRate || this.exchangeRate == 0 || this.sat == 0) {
+        this.tipDialog.paymentMethod = null
         Quasar.Notify.create({
           type: 'negative',
           message:
@@ -953,19 +957,24 @@ window.app = Vue.createApp({
         return
       }
 
+      this.tipDialog.paymentMethod = selectedPaymentMethod
       if (this.tip_options && this.tip_options.length) {
         this.rounding = false
         this.tipRounding = null
         this.showTipModal()
       } else {
-        this.showInvoice()
+        const method = this.tipDialog.paymentMethod
+        this.tipDialog.paymentMethod = null
+        this.showInvoice(method)
       }
     },
     showTipModal() {
       if (!this.atmMode) {
         this.tipDialog.show = true
       } else {
-        this.showInvoice()
+        const method = this.tipDialog.paymentMethod
+        this.tipDialog.paymentMethod = null
+        this.showInvoice(method)
       }
     },
     showPaymentMethod() {
@@ -977,29 +986,46 @@ window.app = Vue.createApp({
     selectPaymentMethod(method) {
       this.currency_choice = false
       if (this._currencyResolver) {
-        switch (method) {
-          case 'fiat_tap':
-            this.fiatMethod = 'terminal'
-            method = 'fiat'
-            break
-          case 'fiat':
-            this.fiatMethod = 'checkout'
-            break
-          case 'cash':
-            this.fiatMethod = 'cash'
-            method = 'fiat'
-            break
-          case 'btc':
-          case 'btc_onchain':
-            this.fiatMethod = 'checkout'
-            break
-          case 'tab':
-            this.fiatMethod = 'checkout'
-            break
-        }
-        this._currencyResolver(method)
+        this._currencyResolver(this.normalizePaymentMethod(method))
         this._currencyResolver = null
       }
+    },
+    normalizePaymentMethod(method) {
+      switch (method) {
+        case 'fiat_tap':
+          this.fiatMethod = 'terminal'
+          return 'fiat'
+        case 'fiat':
+          this.fiatMethod = 'checkout'
+          return 'fiat'
+        case 'cash':
+          this.fiatMethod = 'cash'
+          return 'fiat'
+        case 'btc':
+        case 'btc_onchain':
+        case 'tab':
+          this.fiatMethod = 'checkout'
+          return method
+        default:
+          return method
+      }
+    },
+    normalizeTileSize(value) {
+      if (
+        value === null ||
+        value === undefined ||
+        (typeof value === 'string' && !value.trim())
+      ) {
+        return TILE_SIZE_DEFAULT
+      }
+      const parsed = Number(value)
+      if (!Number.isFinite(parsed)) return TILE_SIZE_DEFAULT
+      const bounded = Math.min(TILE_SIZE_MAX, Math.max(TILE_SIZE_MIN, parsed))
+      return Math.round(bounded / TILE_SIZE_STEP) * TILE_SIZE_STEP
+    },
+    persistTileSize(value) {
+      this.tileSize = this.normalizeTileSize(value)
+      this.$q.localStorage.set(this.tileSizeStorageKey, this.tileSize)
     },
     normalizeApiAmount(currency, value) {
       if (value === null || value === undefined || value === '') return null
@@ -1281,7 +1307,7 @@ window.app = Vue.createApp({
       }
       return params
     },
-    async showInvoice() {
+    async showInvoice(selectedPaymentMethod = null) {
       if (this.atmMode) {
         this.atmGetWithdraw()
         return
@@ -1294,7 +1320,9 @@ window.app = Vue.createApp({
         this.isSettlingTab ||
         (this.tabsEnabled && !this.isSettlingTab)
       ) {
-        const method = await this.showPaymentMethod()
+        const method = selectedPaymentMethod
+          ? this.normalizePaymentMethod(selectedPaymentMethod)
+          : await this.showPaymentMethod()
         if (method === 'tab') {
           await this.openTabChargeDialog()
           return

--- a/templates/tpos/_cart.html
+++ b/templates/tpos/_cart.html
@@ -171,6 +171,18 @@
       :icon="isGridView ? 'view_list' : 'grid_view'"
       @click="isGridView = !isGridView"
     ></q-btn>
+    <q-slider
+      v-if="isGridView"
+      class="col-4 col-sm-3 col-md-2 gt-xs q-px-sm"
+      v-model.number="tileSize"
+      :min="80"
+      :max="240"
+      :step="10"
+      label
+      :label-value="tileSize + 'px'"
+      aria-label="Tile size"
+      @change="persistTileSize"
+    ></q-slider>
     <q-space></q-space>
     <!-- middle: grows -->
     <q-input
@@ -251,7 +263,7 @@
       <!-- sm+ : keep original fixed card size -->
       <div class="flex justify-center q-col-gutter-sm q-mt-md gt-xs">
         <div
-          style="height: 150px; width: 150px"
+          :style="{height: tileSize + 'px', width: tileSize + 'px'}"
           v-for="item in filteredItems"
           :key="item.id"
           v-show="matchesCategoryFilter(item)"
@@ -265,7 +277,11 @@
                 :label="itemCartQty(item.id)"
                 floating
               ></q-badge>
-              <q-img :src="item.image || null" :ratio="4/3" fit="contain">
+              <q-img
+                :src="item.image || null"
+                fit="contain"
+                :style="tileImageStyle"
+              >
               </q-img>
 
               <span class="item-grid-title" dense v-text="item.title"></span>

--- a/templates/tpos/_cart.html
+++ b/templates/tpos/_cart.html
@@ -7,19 +7,21 @@
     :width="drawerWidth"
     :breakpoint="1024"
   >
-    <div class="row full-width q-pa-md">
-      <div class="absolute-top-right q-pa-md">
-        <q-btn @click="cartDrawer = !cartDrawer" icon="close" flat round
-          ><q-tooltip>Hide Cart</q-tooltip></q-btn
-        >
+    <div class="column full-height">
+      <div class="q-pa-md col-auto">
+        <div class="absolute-top-right q-pa-md">
+          <q-btn @click="cartDrawer = !cartDrawer" icon="close" flat round
+            ><q-tooltip>Hide Cart</q-tooltip></q-btn
+          >
+        </div>
+        <div class="col-12 text-center">
+          <h3 class="q-mb-md" v-text="totalFormatted"></h3>
+          <h5 v-show="!denomIsSats" class="q-mt-none q-mb-sm">
+            <span v-text="totalfsat"></span><small> sat</small>
+          </h5>
+        </div>
       </div>
-      <div class="col-12 text-center">
-        <h3 class="q-mb-md" v-text="totalFormatted"></h3>
-        <h5 v-show="!denomIsSats" class="q-mt-none q-mb-sm">
-          <span v-text="totalfsat"></span><small> sat</small>
-        </h5>
-      </div>
-      <div class="col-12" :style="drawerItemsHeight">
+      <div class="q-pa-md q-pt-none col overflow-auto">
         <table class="table full-width" virtual-scroll>
           <colgroup>
             <col width="50%" />
@@ -95,10 +97,8 @@
           </tbody>
         </table>
       </div>
-    </div>
-    <div class="row q-col-gutter-md q-pa-md absolute-bottom q-mb-lg">
-      <div v-if="total > 0" class="col-12">
-        <q-list dense padding class="rounded-borders">
+      <div class="q-pa-md q-pt-none col-auto q-mb-lg">
+        <q-list v-if="total > 0" dense padding class="rounded-borders">
           <q-item>
             <q-item-section> Subtotal </q-item-section>
             <q-item-section side v-text="taxSubtotal"></q-item-section>
@@ -122,25 +122,42 @@
             <q-item-section side v-text="totalFormatted"></q-item-section>
           </q-item>
         </q-list>
-      </div>
-      <div class="col-12 col-sm-6">
-        <q-btn
-          class="full-width"
-          @click="submitForm"
-          color="positive"
-          label="Pay"
-          padding="md"
-          :disabled="cart.size == 0"
-        ></q-btn>
-      </div>
-      <div class="col-12 col-sm-6">
-        <q-btn
-          class="full-width"
-          @click="clearCart"
-          color="negative"
-          label="Clear cart"
-          padding="md"
-        ></q-btn>
+        <div class="row q-col-gutter-md">
+          <div v-if="$q.screen.gt.sm" class="col-12">
+            <tpos-payment-method-selector
+              :bitcoin-symbol="bitcoinSymbol"
+              :currency="currency"
+              :currency-symbol="currencySymbol"
+              :fiat-provider="!!fiatProvider"
+              :allow-cash-settlement="allowCashSettlement"
+              :onchain-enabled="onchainEnabled"
+              :tabs-enabled="tabsEnabled"
+              :is-settling-tab="isSettlingTab"
+              drawer
+              :disabled="cart.size == 0"
+              @select="submitForm"
+            ></tpos-payment-method-selector>
+          </div>
+          <div v-else class="col-12 col-sm-6">
+            <q-btn
+              class="full-width"
+              @click="submitForm()"
+              color="positive"
+              label="Pay"
+              padding="md"
+              :disabled="cart.size == 0"
+            ></q-btn>
+          </div>
+          <div :class="$q.screen.gt.sm ? 'col-12' : 'col-12 col-sm-6'">
+            <q-btn
+              class="full-width"
+              @click="clearCart"
+              color="negative"
+              label="Clear cart"
+              padding="md"
+            ></q-btn>
+          </div>
+        </div>
       </div>
     </div>
   </q-drawer>

--- a/templates/tpos/dialogs.html
+++ b/templates/tpos/dialogs.html
@@ -65,7 +65,11 @@
     @print-receipt="printReceipt"
   ></tpos-print-dialog>
 
-  <q-dialog v-model="tipDialog.show" position="top">
+  <q-dialog
+    v-model="tipDialog.show"
+    position="top"
+    @hide="tipDialog.paymentMethod = null"
+  >
     <q-card class="q-pa-lg q-pt-xl lnbits__dialog-card">
       <div class="text-center q-mb-xl">
         <b style="font-size: 24px">Would you like to leave a tip?</b>
@@ -324,113 +328,17 @@
   <q-dialog v-model="currency_choice">
     <q-card class="q-pa-md">
       <div class="text-h6 q-mb-md">Payment Method</div>
-      <div class="row q-col-gutter-sm q-pt-xs">
-        <div class="col-6">
-          <q-btn
-            class="full-width q-px-lg q-py-sm"
-            size="xl"
-            color="primary"
-            rounded
-            aria-label="Lightning Network"
-            @click="selectPaymentMethod('btc')"
-          >
-            <div class="row items-center no-wrap q-gutter-x-sm">
-              <span
-                class="text-h4 text-weight-bold"
-                v-text="bitcoinSymbol"
-              ></span>
-              <span class="text-subtitle1 text-weight-medium">Lightning</span>
-            </div>
-          </q-btn>
-        </div>
-        <div class="col-6" v-if="onchainEnabled">
-          <q-btn
-            class="full-width q-px-lg q-py-sm"
-            size="xl"
-            color="primary"
-            rounded
-            aria-label="Bitcoin Onchain"
-            @click="selectPaymentMethod('btc_onchain')"
-          >
-            <div class="row items-center no-wrap q-gutter-x-sm">
-              <span
-                class="text-h4 text-weight-bold"
-                v-text="bitcoinSymbol"
-              ></span>
-              <span class="text-subtitle1 text-weight-medium">Onchain</span>
-            </div>
-          </q-btn>
-        </div>
-        <div class="col-6" v-if="fiatProvider">
-          <q-btn
-            class="full-width q-px-lg q-py-sm"
-            size="xl"
-            color="secondary"
-            rounded
-            :aria-label="currency + ' QR'"
-            @click="selectPaymentMethod('fiat')"
-          >
-            <div class="row items-center no-wrap q-gutter-x-xs">
-              <span
-                class="text-h5 text-weight-bold"
-                v-text="currencySymbol"
-              ></span>
-              <q-icon name="qr_code" size="30px"></q-icon>
-            </div>
-          </q-btn>
-        </div>
-        <div class="col-6" v-if="allowCashSettlement && currency != 'sats'">
-          <q-btn
-            class="full-width q-px-lg q-py-sm"
-            size="xl"
-            color="secondary"
-            rounded
-            :aria-label="currency + ' TAP'"
-            @click="selectPaymentMethod('cash')"
-          >
-            <div class="row items-center no-wrap q-gutter-x-xs">
-              <span
-                class="text-h5 text-weight-bold"
-                v-text="currencySymbol"
-              ></span>
-              <q-icon name="toll" size="30px"></q-icon>
-            </div>
-          </q-btn>
-        </div>
-        <div class="col-6" v-if="fiatProvider">
-          <q-btn
-            class="full-width q-px-lg q-py-sm"
-            size="xl"
-            color="secondary"
-            rounded
-            :aria-label="`CASH ${currency}`"
-            @click="selectPaymentMethod('fiat_tap')"
-          >
-            <div class="row items-center no-wrap q-gutter-x-xs">
-              <span
-                class="text-h5 text-weight-bold"
-                v-text="currencySymbol"
-              ></span>
-              <q-icon name="credit_card" size="30px"></q-icon>
-            </div>
-          </q-btn>
-        </div>
-        <div class="col-6" v-if="tabsEnabled && !isSettlingTab">
-          <q-btn
-            class="full-width q-px-lg q-py-sm"
-            size="xl"
-            color="secondary"
-            rounded
-            aria-label="Add to tab"
-            @click="selectPaymentMethod('tab')"
-          >
-            <div class="row items-center no-wrap q-gutter-x-xs">
-              <q-icon class="text-h4" name="playlist_add_check"></q-icon>
-              <span class="text-subtitle1 text-weight-medium">Tab</span>
-            </div>
-          </q-btn>
-        </div>
-      </div>
+      <tpos-payment-method-selector
+        :bitcoin-symbol="bitcoinSymbol"
+        :currency="currency"
+        :currency-symbol="currencySymbol"
+        :fiat-provider="!!fiatProvider"
+        :allow-cash-settlement="allowCashSettlement"
+        :onchain-enabled="onchainEnabled"
+        :tabs-enabled="tabsEnabled"
+        :is-settling-tab="isSettlingTab"
+        @select="selectPaymentMethod"
+      ></tpos-payment-method-selector>
     </q-card>
   </q-dialog>
 

--- a/templates/tpos/tpos.html
+++ b/templates/tpos/tpos.html
@@ -245,6 +245,7 @@
 <script src="{{ static_url_for('tpos/static', path='js/tpos.js') }}"></script>
 <script src="{{ static_url_for('tpos/static', path='components/item-list.js') }}"></script>
 <script src="{{ static_url_for('tpos/static', path='components/keypad.js') }}"></script>
+<script src="{{ static_url_for('tpos/static', path='components/payment-method-selector.js') }}"></script>
 <script src="{{ static_url_for('tpos/static', path='components/payment-dialog.js') }}"></script>
 <script src="{{ static_url_for('tpos/static', path='components/held-carts-dialog.js') }}"></script>
 <script src="{{ static_url_for('tpos/static', path='components/print-dialog.js') }}"></script>

--- a/tests/check_static_load.js
+++ b/tests/check_static_load.js
@@ -37,6 +37,7 @@ const pages = [
       'static/js/tpos.js',
       'static/components/item-list.js',
       'static/components/keypad.js',
+      'static/components/payment-method-selector.js',
       'static/components/payment-dialog.js',
       'static/components/held-carts-dialog.js',
       'static/components/print-dialog.js',

--- a/tests/e2e/tpos.spec.ts
+++ b/tests/e2e/tpos.spec.ts
@@ -66,29 +66,107 @@ test('public item checkout completes through Lightning with FakeWallet', async (
         disabled: false
       }
     ]),
-    tip_options: '[]',
+    tip_options: '[10]',
     enable_remote: false,
-    tabs_enabled: false
+    tabs_enabled: true
   })
 
   await page.goto(`/tpos/${terminal.id}`)
   const pos = page.locator('body')
+  const tile = pos.locator('div.flex.justify-center.gt-xs > div').first()
+  await expect(tile).toBeVisible()
+  await expect
+    .poll(() =>
+      tile.evaluate(element => {
+        const style = getComputedStyle(element)
+        return {height: style.height, width: style.width}
+      })
+    )
+    .toEqual({height: '150px', width: '150px'})
+  await page.evaluate(
+    key => window.localStorage.setItem(key, JSON.stringify('invalid')),
+    `lnbits.tpos.${terminal.id}.tileSize`
+  )
+  await page.reload()
+  const fallbackTile = pos
+    .locator('div.flex.justify-center.gt-xs > div')
+    .first()
+  await expect
+    .poll(() =>
+      fallbackTile.evaluate(element => getComputedStyle(element).width)
+    )
+    .toBe('150px')
+  const tileSizeSlider = pos.locator('[aria-label="Tile size"]')
+  await expect(tileSizeSlider).toBeVisible()
+  await tileSizeSlider.focus()
+  await tileSizeSlider.press('ArrowRight', {delay: 50})
+  await tileSizeSlider.press('ArrowRight', {delay: 50})
+  await tileSizeSlider.press('ArrowRight', {delay: 50})
+  await tileSizeSlider.press('ArrowRight', {delay: 50})
+  await tileSizeSlider.press('ArrowRight', {delay: 50})
+  await expect
+    .poll(() =>
+      tile.evaluate(element => {
+        const style = getComputedStyle(element)
+        return {height: style.height, width: style.width}
+      })
+    )
+    .toEqual({height: '200px', width: '200px'})
+  await expect
+    .poll(() =>
+      page.evaluate(key => {
+        const value = window.localStorage.getItem(key)
+        return value === null ? null : JSON.parse(value)
+      }, `lnbits.tpos.${terminal.id}.tileSize`)
+    )
+    .toBe(200)
+  await page.reload()
+  const restoredTile = pos
+    .locator('div.flex.justify-center.gt-xs > div')
+    .first()
+  await expect
+    .poll(() =>
+      restoredTile.evaluate(element => getComputedStyle(element).width)
+    )
+    .toBe('200px')
+  await page.setViewportSize({width: 1280, height: 600})
+  await page.reload()
   const item = pos
     .locator('.item-grid-title:visible')
     .filter({hasText: itemName})
   await expect(item).toBeVisible()
   await item.click()
   await expect(pos.getByText('Total', {exact: true}).last()).toBeVisible()
+  const clearCart = pos.getByRole('button', {name: /clear cart/i})
+  await expect(clearCart).toBeVisible()
+  const clearCartBox = await clearCart.boundingBox()
+  expect(clearCartBox).not.toBeNull()
+  expect(clearCartBox!.y).toBeGreaterThanOrEqual(420)
+  expect(clearCartBox!.y + clearCartBox!.height).toBeLessThanOrEqual(592)
+  await expect(pos.getByRole('button', {name: /^pay$/i})).toHaveCount(0)
+  await pos.getByRole('button', {name: /lightning network/i}).click()
+  const tipDialog = pos
+    .locator('.q-dialog')
+    .filter({hasText: 'Would you like to leave a tip?'})
+    .last()
+  await expect(tipDialog).toBeVisible()
+  await expect(
+    pos.locator('.q-dialog').filter({hasText: 'Payment Method'})
+  ).toHaveCount(0)
   const invoiceResponse = page.waitForResponse(
     response =>
       response.request().method() === 'POST' &&
       response.url().includes(`/tpos/api/v1/tposs/${terminal.id}/invoices`)
   )
-  await pos.getByRole('button', {name: /^pay$/i}).click()
-  const invoice = (await (await invoiceResponse).json()) as {
+  await tipDialog.getByRole('button', {name: /no, thanks/i}).click()
+  const invoiceResponseResult = await invoiceResponse
+  const invoice = (await invoiceResponseResult.json()) as {
     bolt11?: string
   }
   expect(invoice.bolt11).toMatch(/^lnbc/i)
+  expect(invoiceResponseResult.request().postDataJSON()).toMatchObject({
+    payment_method: 'btc'
+  })
   await payInvoice(page, customerWallet, invoice.bolt11 as string)
   await expect(pos.getByText('Invoice Paid!', {exact: true})).toBeVisible({
     timeout: 60_000
@@ -96,6 +174,49 @@ test('public item checkout completes through Lightning with FakeWallet', async (
   await expect(
     pos.locator('table tbody tr').filter({hasText: itemName})
   ).toHaveCount(0)
+
+  await page.setViewportSize({width: 800, height: 900})
+  await page.reload()
+  await pos.getByText(itemName, {exact: true}).last().click()
+  await pos.getByRole('button', {name: /checkout/i}).click()
+  await expect(pos.getByRole('button', {name: /^pay$/i})).toBeVisible()
+  await expect(
+    pos.getByRole('button', {name: /lightning network/i})
+  ).toHaveCount(0)
+  await pos.getByRole('button', {name: /^pay$/i}).click()
+  const paymentMethodDialog = pos
+    .locator('.q-dialog')
+    .filter({hasText: 'Payment Method'})
+    .last()
+  const compactTipDialog = pos
+    .locator('.q-dialog')
+    .filter({hasText: 'Would you like to leave a tip?'})
+    .last()
+  await expect(compactTipDialog).toBeVisible()
+  await expect(paymentMethodDialog).toHaveCount(0)
+  await compactTipDialog.getByRole('button', {name: /no, thanks/i}).click()
+  await expect(paymentMethodDialog).toBeVisible()
+  const compactInvoiceResponse = page.waitForResponse(
+    response =>
+      response.request().method() === 'POST' &&
+      response.url().includes(`/tpos/api/v1/tposs/${terminal.id}/invoices`)
+  )
+  await paymentMethodDialog
+    .getByRole('button', {name: /lightning network/i})
+    .click()
+  const compactInvoiceResponseResult = await compactInvoiceResponse
+  const compactInvoice = (await compactInvoiceResponseResult.json()) as {
+    bolt11?: string
+  }
+  expect(compactInvoice.bolt11).toMatch(/^lnbc/i)
+  expect(compactInvoiceResponseResult.request().postDataJSON()).toMatchObject({
+    payment_method: 'btc'
+  })
+
+  await page.setViewportSize({width: 500, height: 900})
+  await page.reload()
+  await expect(pos.locator('[aria-label="Tile size"]')).toHaveCount(0)
+  await expect(pos.getByText(itemName, {exact: true}).last()).toBeVisible()
 })
 
 test('held carts survive restore and can then be deleted', async ({


### PR DESCRIPTION
Adds the payment method chooser on the right/cart drawer, substituting the pay button. Instead of Pay -> select method, now select method triggers the pay for that method.

<img width="1307" height="827" alt="image" src="https://github.com/user-attachments/assets/de475005-7463-45f9-ad4d-f9058a26fc5f" />

<img width="377" height="784" alt="image" src="https://github.com/user-attachments/assets/75f80efa-e3a2-49fb-80d6-a9cc7681385d" />


Adds a top slider that allows for changing the size of the item cards.

<img width="1307" height="827" alt="image" src="https://github.com/user-attachments/assets/0e3360c3-ca99-4c7d-8e0e-33bfbb2e19fd" />

Both UI/UX fixes target wide/tablet screen sizes only.

Closes #232 
Closes #233